### PR TITLE
Fix for metrics failing to deploy on kube 1.16+

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.5.1
+appVersion: 1.5.2
 description: A Helm chart for Stratos Metrics
 name: metrics
-version: 1.1.1
+version: 1.1.2
 sources:
   - https://github.com/SUSE/stratos-metrics
 icon: https://raw.githubusercontent.com/SUSE/stratos-metrics/master/icon.svg

--- a/build/ci/travis/helm-chart-unit-tests.sh
+++ b/build/ci/travis/helm-chart-unit-tests.sh
@@ -24,8 +24,10 @@ helm dependency build
 # Since the chart is in the root folder, we need to ensure its in a folder named 'metrics'
 mkdir -p ./tmp/metrics
 cp *.yaml ./tmp/metrics
-cp -R templates/ ./tmp/metrics
-cp -R tests/ ./tmp/metrics
+cp *.lock ./tmp/metrics
+cp -R ./templates ./tmp/metrics
+cp -R ./tests ./tmp/metrics
+cp -R ./charts ./tmp/metrics
 
 # Run unit tests
 helm unittest ./tmp/metrics

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 7.3.6
-digest: sha256:d8b0a6d7b4d3195b3833ba265bdb4fad4247eb8c636120d895402c9d3e29fbb8
-generated: 2018-11-06T09:46:52.125751248Z
+  version: 10.3.0
+digest: sha256:805e4b79f55f59a0db2216d56e7848debb88c6d1d2384ab25ef17514669952a5
+generated: 2020-01-16T11:58:09.348788Z

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: prometheus
-  version: "7.3.6"
+  version: "10.3.0"
   repository: "https://kubernetes-charts.storage.googleapis.com"

--- a/templates/cf-exporter.yaml
+++ b/templates/cf-exporter.yaml
@@ -2,7 +2,11 @@
 {{- if .Values.cfExporter.enabled }}
 {{ $cfExporterClientSecret :=  default (randAlphaNum 64) .Values.cfExporter.uaa.clientSecret }}
 ---
+{{- if semverCompare ">=1.16" (printf "%s.%s" .Capabilities.KubeVersion.Major (trimSuffix "+" .Capabilities.KubeVersion.Minor) )}}
+apiVersion: apps/v1
+{{- else }}
 apiVersion: apps/v1beta1
+{{- end }}
 kind: Deployment
 metadata:
   name: "{{ .Release.Name }}-cf-exporter"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,6 +1,10 @@
 {{ $firehoseClientSecret :=  default (randAlphaNum 64) .Values.firehoseExporter.uaa.clientSecret }}
 ---
+{{- if semverCompare ">=1.16" (printf "%s.%s" .Capabilities.KubeVersion.Major (trimSuffix "+" .Capabilities.KubeVersion.Minor) )}}
+apiVersion: apps/v1
+{{- else }}
 apiVersion: apps/v1beta1
+{{- end }}
 kind: Deployment
 metadata:
   name: "{{ .Release.Name }}-nginx"
@@ -115,10 +119,15 @@ spec:
 {{ $helmChartVersion :=  .Chart.Version }}
 {{ $values :=  .Values }}
 {{ $dot := . }}
+{{ $caps := .Capabilities }}
   {{- range int .Values.firehoseExporter.instances | until }}
 
 ---
+{{- if semverCompare ">=1.16" (printf "%s.%s" $caps.KubeVersion.Major (trimSuffix "+" $caps.KubeVersion.Minor) )}}
+apiVersion: apps/v1
+{{- else }}
 apiVersion: apps/v1beta1
+{{- end }}
 kind: Deployment
 metadata:
   name: "{{ $releaseName }}-firehose-exporters-{{ . }}"

--- a/templates/service-exporter.yaml
+++ b/templates/service-exporter.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.firehoseExporter.enabled }}
+{{ $releaseName := .Release.Name }}
+{{ $firehoseExporter := .Values.firehoseExporter }}
+{{ $appVersion := .Chart.AppVersion }}
+{{ $helmChartName :=  .Chart.Name }}
+{{ $helmChartVersion :=  .Chart.Version }}
+{{- range int .Values.firehoseExporter.instances | until }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $releaseName }}-f-exp-service-{{ . }}
+  labels:
+    app.kubernetes.io/name: "stratos-metrics"
+    app.kubernetes.io/instance: "{{ $releaseName }}"
+    app.kubernetes.io/version: "{{ $appVersion }}"
+    app.kubernetes.io/component: "stratos-metrics-firehose-exporter-service-{{ . }}"
+    helm.sh/chart: "{{ $helmChartName }}-{{ $helmChartVersion | replace "+" "_" }}"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9186
+    targetPort: 9186
+    protocol: TCP
+    name: f-exp-service
+  selector:
+    app.kubernetes.io/name: "stratos-metrics"
+    app.kubernetes.io/component: "stratos-metrics-firehose-exporters-{{ . }}"
+  {{- end }}
+{{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -53,34 +53,3 @@ spec:
     app.kubernetes.io/name: "stratos-metrics"
     app.kubernetes.io/component: "stratos-metrics-nginx"
 
-{{- if .Values.firehoseExporter.enabled }}
-
-{{ $releaseName := .Release.Name }}
-{{ $firehoseExporter := .Values.firehoseExporter }}
-{{ $appVersion := .Chart.AppVersion }}
-{{ $helmChartName :=  .Chart.Name }}
-{{ $helmChartVersion :=  .Chart.Version }}
-  {{- range int .Values.firehoseExporter.instances | until }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ $releaseName }}-f-exp-service-{{ . }}
-  labels:
-    app.kubernetes.io/name: "stratos-metrics"
-    app.kubernetes.io/instance: "{{ $releaseName }}"
-    app.kubernetes.io/version: "{{ $appVersion }}"
-    app.kubernetes.io/component: "stratos-metrics-firehose-exporter-service-{{ . }}"
-    helm.sh/chart: "{{ $helmChartName }}-{{ $helmChartVersion | replace "+" "_" }}"
-spec:
-  type: ClusterIP
-  ports:
-  - port: 9186
-    targetPort: 9186
-    protocol: TCP
-    name: f-exp-service
-  selector:
-    app.kubernetes.io/name: "stratos-metrics"
-    app.kubernetes.io/component: "stratos-metrics-firehose-exporters-{{ . }}"
-  {{- end }}
-{{- end }}

--- a/tests/service_test.yaml
+++ b/tests/service_test.yaml
@@ -12,7 +12,7 @@ tests:
   - it: should have default ClusterIP configuration
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - equal:
           path: spec.type
           value: ClusterIP
@@ -28,7 +28,7 @@ tests:
       metrics.service.servicePort: 12443
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - equal:
           path: spec.type
           value: ClusterIP
@@ -74,7 +74,7 @@ tests:
       metrics.service.clusterIP: 5.6.7.8
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - equal:
           path: spec.clusterIP
           value: 5.6.7.8
@@ -83,7 +83,7 @@ tests:
       useLb: true
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - equal:
           path: spec.type
           value: LoadBalancer
@@ -93,7 +93,7 @@ tests:
       metrics.service.loadBalancerIP: 1.2.3.4
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - equal:
           path: spec.type
           value: LoadBalancer
@@ -105,7 +105,7 @@ tests:
       services.loadbalanced: true
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - equal:
           path: spec.type
           value: LoadBalancer


### PR DESCRIPTION
Had to separate out services - looks like there is an issue where we get json.Number and not int when running helm unittest - so can't test the exporter service. Will need to look into this.