### PR TITLE
Helm Chart: Add NOTES.txt template & update chart.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,3 +6,12 @@ version: 1.2.1
 sources:
   - https://github.com/SUSE/stratos-metrics
 icon: https://raw.githubusercontent.com/SUSE/stratos-metrics/master/icon.svg
+maintainers:
+  - name: Stratos @ SUSE
+    email: "TODO: RC"
+    url: https://stratos.app
+keywords:
+  - Stratos
+  - "Cloud Foundry"
+  - Kubernetes
+  - Helm

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,9 +7,9 @@ sources:
   - https://github.com/SUSE/stratos-metrics
 icon: https://raw.githubusercontent.com/SUSE/stratos-metrics/master/icon.svg
 maintainers:
-  - name: Stratos @ SUSE
-    email: "TODO: RC"
-    url: https://stratos.app
+  - name: Stratos Maintainers
+    email: stratos-maintainers@suse.de
+    home: https://stratos.app
 keywords:
   - Stratos
   - "Cloud Foundry"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -9,9 +9,12 @@ icon: https://raw.githubusercontent.com/SUSE/stratos-metrics/master/icon.svg
 maintainers:
   - name: Stratos Maintainers
     email: stratos-maintainers@suse.de
-    home: https://stratos.app
+home: https://stratos.app
 keywords:
   - Stratos
   - "Cloud Foundry"
   - Kubernetes
   - Helm
+  - Monitoring
+  - Prometheus
+  - Metrics

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,0 +1,7 @@
+Thank you for installing Stratos Metrics. Your release is named '{{ .Release.Name }}' and is in the namespace '{{ .Release.Namespace }}'.
+
+To learn more about the release, try:
+  $ helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ helm get values {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ kubectl get services -n {{ .Release.Namespace }}
+  $ kubectl get pods -n {{ .Release.Namespace }}


### PR DESCRIPTION
- Add NOTES template
- Add maintainers and keywords to chart.yaml
- contributes to https://github.com/cloudfoundry/stratos/issues/4556

helm install looks like...
```
richard@linux-o35c ~/dev/github/stratos-metrics/build (notes-and-maintainers) $ helm status my-metrics -n my-metrics
NAME: my-metrics
LAST DEPLOYED: Thu Sep  3 14:16:47 2020
NAMESPACE: my-metrics
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing Stratos Metrics. Your release is named 'my-metrics' and is in the namespace 'my-metrics'.

To learn more about the release, try:
  $ helm status my-metrics -n my-metrics
  $ helm get values my-metrics -n my-metrics
  $ kubectl get services -n my-metrics
  $ kubectl get pods -n my-metrics

```